### PR TITLE
Add support for closing the Sentry instance

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -137,6 +137,39 @@ import { GraphqlInterceptor } from '@ntegral/nestjs-sentry';
 export class AppModule {}
 ```
 
+## Flushing sentry
+Sentry does not flush all the errors by itself, it does it in background so that it doesn't block the main thread. If 
+you kill the nestjs app forcefully some exceptions don't have to be flushed and logged successfully.
+
+If you want to force that behaviour use the close flag in your options. That is handy if using nestjs as a console
+runner. Keep in mind that you need to have ```app.enableShutdownHooks();``` enabled in order 
+for closing (flushing) to work.
+
+```typescript
+import { Module } from '@nestjs-common';
+import { SentryModule } from '@ntegral/nestjs-sentry';
+import { LogLevel } from '@sentry/types';
+
+@Module({
+  imports: [
+    SentryModule.forRoot({
+      dsn: 'sentry_io_dsn',
+      debug: true | false,
+      environment: 'dev' | 'production' | 'some_environment',
+      release: 'some_release', | null, // must create a release in sentry.io dashboard
+      logLevel: LogLevel.Debug //based on sentry.io loglevel //
+      close: {
+        enabled: true,
+        // Time in milliseconds to forcefully quit the application  
+        timeout?: number,  
+      }
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+
 ## Contributing
 
 I would greatly appreciate any contributions to make this project better. Please

--- a/lib/sentry.interfaces.ts
+++ b/lib/sentry.interfaces.ts
@@ -3,8 +3,15 @@ import { Integration, Options } from '@sentry/types';
 import { Severity } from "@sentry/node";
 import { ConsoleLoggerOptions } from "@nestjs/common";
 
+export interface SentryCloseOptions {
+    enabled: boolean;
+    // timeout – Maximum time in ms the client should wait until closing forcefully
+    timeout?: number;
+}
+
 export type SentryModuleOptions = Omit<Options, 'integrations'> & {
     integrations?: Integration[];
+    close?: SentryCloseOptions
 } & ConsoleLoggerOptions;
 
 export interface SentryOptionsFactory {

--- a/lib/sentry.service.ts
+++ b/lib/sentry.service.ts
@@ -1,12 +1,13 @@
 import { Inject, Injectable, ConsoleLogger } from '@nestjs/common';
 import { Options, Client } from '@sentry/types';
 import * as Sentry from '@sentry/node';
+import { OnApplicationShutdown } from '@nestjs/common';
 
 import { SENTRY_MODULE_OPTIONS } from './sentry.constants';
 import { SentryModuleOptions } from './sentry.interfaces';
 
 @Injectable()
-export class SentryService extends ConsoleLogger {
+export class SentryService extends ConsoleLogger implements OnApplicationShutdown {
   app = '@ntegral/nestjs-sentry: ';
   private static serviceInstance: SentryService;
   constructor(
@@ -93,5 +94,11 @@ export class SentryService extends ConsoleLogger {
 
   instance() {
     return Sentry;
+  }
+
+  async onApplicationShutdown(signal?: string) {
+    if (this.opts?.close?.enabled === true) {
+      await Sentry.close(this.opts?.close.timeout);
+    }
   }
 }


### PR DESCRIPTION
If nestjs is forcefully closed (for example if using with nestjs-console) it could happen that some of the Sentry exceptions are not logged. I've added functionality that prevents that from happening. It is optional in the config. I've added a test for that functionality and created a docs paragraph documenting that functionality.

Would love some feedback.