### PR TITLE
Making logging optional

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -59,7 +59,7 @@ import { LogLevel } from '@sentry/types';
       dsn: 'sentry_io_dsn',
       debug: true | false,
       environment: 'dev' | 'production' | 'some_environment',
-      release: 'some_release', | null, // must create a release in sentry.io dashboard
+      release: 'some_release' | null, // must create a release in sentry.io dashboard
       logLevel: LogLevel.Debug //based on sentry.io loglevel //
     }),
   ],
@@ -83,7 +83,7 @@ import { ConfigService } from '@ntegral/nestjs-config';
         dsn: cfg.get('SENTRY_DSN'),
         debug: true | false,
         environment: 'dev' | 'production' | 'some_environment',
-        release: 'some_release', | null, // must create a release in sentry.io dashboard
+        release: 'some_release' | null, // must create a release in sentry.io dashboard
         logLevel: LogLevel.Debug //based on sentry.io loglevel //
       }),
       inject: [ConfigService],
@@ -109,6 +109,76 @@ export class AppService {
       ... and more
   }
 }
+```
+
+## Logging
+
+You can provide a custom logger which implements `NestJS`'s `LoggerService` interface: 
+
+```typescript
+import { Module } from '@nestjs-common';
+import { SentryModule } from '@ntegral/nestjs-sentry';
+import { LogLevel } from '@sentry/types';
+
+@Module({
+  imports: [
+    SentryModule.forRoot({
+      dsn: 'sentry_io_dsn',
+      debug: true | false,
+      environment: 'dev' | 'production' | 'some_environment',
+      release: 'some_release' | null, // must create a release in sentry.io dashboard
+      logLevel: LogLevel.Debug, //based on sentry.io loglevel //
+      logger: new MyLogger(), // implements LoggerService
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+Or completely disable logging:
+
+```typescript
+import { Module } from '@nestjs-common';
+import { SentryModule } from '@ntegral/nestjs-sentry';
+import { LogLevel } from '@sentry/types';
+
+@Module({
+  imports: [
+    SentryModule.forRoot({
+      dsn: 'sentry_io_dsn',
+      debug: true | false,
+      environment: 'dev' | 'production' | 'some_environment',
+      release: 'some_release' | null, // must create a release in sentry.io dashboard
+      logLevel: LogLevel.Debug, //based on sentry.io loglevel //
+      logger: null
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+Or you can provide default logger (`ConsoleLogger`) options:
+
+```typescript
+import { Module } from '@nestjs-common';
+import { SentryModule } from '@ntegral/nestjs-sentry';
+import { LogLevel } from '@sentry/types';
+
+@Module({
+  imports: [
+    SentryModule.forRoot({
+      dsn: 'sentry_io_dsn',
+      debug: true | false,
+      environment: 'dev' | 'production' | 'some_environment',
+      release: 'some_release' | null, // must create a release in sentry.io dashboard
+      logLevel: LogLevel.Debug, //based on sentry.io loglevel //
+      loggerOptions: {
+        timestamp: true,
+      },
+    }),
+  ],
+})
+export class AppModule {}
 ```
 
 ## Interceptors

--- a/lib/createSentryService.ts
+++ b/lib/createSentryService.ts
@@ -1,0 +1,13 @@
+import { SentryModuleOptions } from './sentry.interfaces';
+import { SentryService } from './sentry.service';
+import { ConsoleLogger } from '@nestjs/common';
+
+export function createSentryService(options: SentryModuleOptions): SentryService {
+  const opts: SentryModuleOptions = {...options};
+
+  if (typeof opts.logger === 'undefined') {
+    opts.logger = new ConsoleLogger('', opts.loggerOptions || {});
+  }
+
+  return new SentryService(opts);
+}

--- a/lib/sentry-core.module.ts
+++ b/lib/sentry-core.module.ts
@@ -16,6 +16,7 @@ import {
 } from './sentry.constants';
 import { SentryService } from './sentry.service';
 import { createSentryProviders } from './sentry.providers';
+import { createSentryService } from './createSentryService';
 
 @Global()
 @Module({})
@@ -25,9 +26,9 @@ export class SentryCoreModule {
         const provider = createSentryProviders(options);
 
         return {
-            exports: [provider, SentryService],
+            exports: [provider],
             module: SentryCoreModule,
-            providers: [provider, SentryService],
+            providers: [provider],
         };
     }
 
@@ -37,7 +38,7 @@ export class SentryCoreModule {
         const provider: Provider = {
             inject: [SENTRY_MODULE_OPTIONS],
             provide: SENTRY_TOKEN,
-            useFactory: (options: SentryModuleOptions) => new SentryService(options),
+            useFactory: (options: SentryModuleOptions) => createSentryService(options),
         };
 
         return {

--- a/lib/sentry.interfaces.ts
+++ b/lib/sentry.interfaces.ts
@@ -1,7 +1,7 @@
 import { ModuleMetadata, Type } from "@nestjs/common/interfaces";
 import { Integration, Options } from '@sentry/types';
 import { Severity } from "@sentry/node";
-import { ConsoleLoggerOptions } from "@nestjs/common";
+import { ConsoleLoggerOptions, LoggerService } from '@nestjs/common';
 
 export interface SentryCloseOptions {
     enabled: boolean;
@@ -9,10 +9,15 @@ export interface SentryCloseOptions {
     timeout?: number;
 }
 
+export interface LoggingOptions {
+    logger?: LoggerService | null;
+    loggerOptions?: ConsoleLoggerOptions;
+}
+
 export type SentryModuleOptions = Omit<Options, 'integrations'> & {
     integrations?: Integration[];
     close?: SentryCloseOptions
-} & ConsoleLoggerOptions;
+} & LoggingOptions;
 
 export interface SentryOptionsFactory {
     createSentryModuleOptions(): Promise<SentryModuleOptions> | SentryModuleOptions;

--- a/lib/sentry.providers.ts
+++ b/lib/sentry.providers.ts
@@ -1,11 +1,11 @@
 import { Provider } from '@nestjs/common';
 import { SentryModuleOptions } from './sentry.interfaces';
 import { SENTRY_TOKEN } from './sentry.constants';
-import { SentryService } from './sentry.service';
+import { createSentryService } from './createSentryService';
 
 export function createSentryProviders(options: SentryModuleOptions) : Provider {
     return {
         provide: SENTRY_TOKEN,
-        useValue: new SentryService(options),
+        useValue: createSentryService(options),
     }
 }

--- a/lib/sentry.service.ts
+++ b/lib/sentry.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, ConsoleLogger } from '@nestjs/common';
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { Options, Client } from '@sentry/types';
 import * as Sentry from '@sentry/node';
 import { OnApplicationShutdown } from '@nestjs/common';
@@ -7,14 +7,13 @@ import { SENTRY_MODULE_OPTIONS } from './sentry.constants';
 import { SentryModuleOptions } from './sentry.interfaces';
 
 @Injectable()
-export class SentryService extends ConsoleLogger implements OnApplicationShutdown {
+export class SentryService implements LoggerService, OnApplicationShutdown {
   app = '@ntegral/nestjs-sentry: ';
   private static serviceInstance: SentryService;
   constructor(
     @Inject(SENTRY_MODULE_OPTIONS)
     readonly opts?: SentryModuleOptions,
   ) {
-    super();
     if (!(opts && opts.dsn)) {
       // console.log('options not found. Did you use SentryModule.forRoot?');
       return;
@@ -55,15 +54,19 @@ export class SentryService extends ConsoleLogger implements OnApplicationShutdow
   log(message: string, context?: string) {
     message = `${this.app} ${message}`;
     try {
+      if (this.opts && this.opts.logger) {
+        this.opts.logger.log(message, context);
+      }
       Sentry.captureMessage(message, Sentry.Severity.Log);
-      super.log(message, context);
     } catch (err) {}
   }
 
   error(message: string, trace?: string, context?: string) {
     message = `${this.app} ${message}`;
     try {
-      super.error(message, trace, context);
+      if (this.opts && this.opts.logger) {
+        this.opts.logger.error(message, trace, context);
+      }
       Sentry.captureMessage(message, Sentry.Severity.Error);
     } catch (err) {}
   }
@@ -71,7 +74,9 @@ export class SentryService extends ConsoleLogger implements OnApplicationShutdow
   warn(message: string, context?: string) {
     message = `${this.app} ${message}`;
     try {
-      super.warn(message, context);
+      if (this.opts && this.opts.logger) {
+        this.opts.logger.warn(message, context);
+      }
       Sentry.captureMessage(message, Sentry.Severity.Warning);
     } catch (err) {}
   }
@@ -79,7 +84,9 @@ export class SentryService extends ConsoleLogger implements OnApplicationShutdow
   debug(message: string, context?: string) {
     message = `${this.app} ${message}`;
     try {
-      super.debug(message, context);
+      if (this.opts && this.opts.logger && this.opts.logger.debug) {
+        this.opts.logger.debug(message, context);
+      }
       Sentry.captureMessage(message, Sentry.Severity.Debug);
     } catch (err) {}
   }
@@ -87,7 +94,9 @@ export class SentryService extends ConsoleLogger implements OnApplicationShutdow
   verbose(message: string, context?: string) {
     message = `${this.app} ${message}`;
     try {
-      super.verbose(message, context);
+      if (this.opts && this.opts.logger && this.opts.logger.verbose) {
+        this.opts.logger.verbose(message, context);
+      }
       Sentry.captureMessage(message, Sentry.Severity.Info);
     } catch (err) {}
   }


### PR DESCRIPTION
- get rid of ConsoleLogger inheritance:
   - use `SentryService implements LoggerService` instead of `SentryService extends ConsoleLogger`;
- add an ability to provide custom logger;
- add an ability to disable logging entirely;
- default logger is `ConsoleLogger` for backward compatibility;