### PR TITLE
Pass options from interceptor to parseRequest

### DIFF
--- a/lib/sentry.interceptor.ts
+++ b/lib/sentry.interceptor.ts
@@ -67,7 +67,7 @@ export class SentryInterceptor implements NestInterceptor {
   }
 
   private captureHttpException(scope: Scope, http: HttpArgumentsHost, exception: any): void {
-    const data = Handlers.parseRequest(<any>{},http.getRequest(), {});
+    const data = Handlers.parseRequest(<any>{},http.getRequest(), this.options);
 
     scope.setExtra('req', data.request);
     


### PR DESCRIPTION
### Issue

By default the parseRequest method called from @sentry/node package passes an empty object for parsing the express request. 

This leads to in my case the user object not being parsed currectly from the request because of the following:

Referring to the code in https://github.com/getsentry/sentry-javascript/blob/master/packages/node/src/handlers.ts#L338

User by default is true so it will try and pull the keys from the object.

```typescript
  if (options.user) {
    const extractedUser = req.user && isPlainObject(req.user) ? extractUserData(req.user, options.user) : {};

    if (Object.keys(extractedUser)) {
      event.user = {
        ...event.user,
        ...extractedUser,
      };
    }
  }
 ```

In `extractUserData`  https://github.com/getsentry/sentry-javascript/blob/d3ca7a897263141e9f0821e8be2a8cb617638d4d/packages/node/src/handlers.ts#L167

If no keys are provided the following will be parsed.

```typescript
const DEFAULT_USER_KEYS = ['id', 'username', 'email'];
```

In most jwt applications additional keys are povided and used.

### Resolution

To fix this I pass SentryInterceptorOptions to @sentry/node parseRequest to allow the ability to provide user object keys outside of the default keys array.

Like so:

```typescript
const data = Handlers.parseRequest(<any>{},http.getRequest(), this.options);
```

### Example

This allows for the following implementation.

```typescript
app.useGlobalInterceptors(new SentryInterceptor({
    user: [
      'iss',
      'sub',
      'aud',
      'iat',
      'exp',
      'azp',
      'scope',
      '<some other claim>',
  ]
  }))
```