### PR TITLE
Updated README example of using GraphqlInterceptor

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -130,7 +130,7 @@ import { GraphqlInterceptor } from '@ntegral/nestjs-sentry';
   providers: [
     {
       provide: APP_INTERCEPTOR,
-      useClass: GraphqlInterceptor,
+      useFactory: () => new GraphqlInterceptor(),
     },
   ],
 })


### PR DESCRIPTION
Using useFactory() instead of useClass until sentry module exports and provides GraphqlInterceptor