### PR TITLE
Updated readme to reflect current implementation of logLevels

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -51,7 +51,6 @@ The simplest way to use `@ntegral/nestjs-sentry` is to use `SentryModule.forRoot
 ```typescript
 import { Module } from '@nestjs-common';
 import { SentryModule } from '@ntegral/nestjs-sentry';
-import { LogLevel } from '@sentry/types';
 
 @Module({
   imports: [
@@ -60,7 +59,7 @@ import { LogLevel } from '@sentry/types';
       debug: true | false,
       environment: 'dev' | 'production' | 'some_environment',
       release: 'some_release', | null, // must create a release in sentry.io dashboard
-      logLevel: LogLevel.Debug //based on sentry.io loglevel //
+      logLevels: ['debug'] 
     }),
   ],
 })
@@ -84,7 +83,7 @@ import { ConfigService } from '@ntegral/nestjs-config';
         debug: true | false,
         environment: 'dev' | 'production' | 'some_environment',
         release: 'some_release', | null, // must create a release in sentry.io dashboard
-        logLevel: LogLevel.Debug //based on sentry.io loglevel //
+        logLevels: ['debug'] //based on sentry.io loglevel //
       }),
       inject: [ConfigService],
     })
@@ -189,7 +188,7 @@ import { LogLevel } from '@sentry/types';
       debug: true | false,
       environment: 'dev' | 'production' | 'some_environment',
       release: 'some_release', | null, // must create a release in sentry.io dashboard
-      logLevel: LogLevel.Debug //based on sentry.io loglevel //
+      logLevels: ['debug']
       close: {
         enabled: true,
         // Time in milliseconds to forcefully quit the application  


### PR DESCRIPTION
Looks like the implementation of SentryModule.forRoot on version 6.17.4 changed on how logLevel is passed. Now it's spelled as logLevels and it receives a type of LogLevel[]. Also the type LogLevel doesn't seem to exist anymore. Documentation needs to be updated in order to avoid type conflicts.

Before:
```
SentryModule.forRoot({
...
logLevel: LogLevel.Debug
})
```
Now:
```
SentryModule.forRoot({
logLevels: ['debug']
})
```