### PR TITLE
🐛 exception filter implement OR logic instead of AND

### DIFF
--- a/lib/sentry.interceptor.ts
+++ b/lib/sentry.interceptor.ts
@@ -101,12 +101,12 @@ export class SentryInterceptor implements NestInterceptor {
   private shouldReport(exception: any) {
     if (this.options && !this.options.filters) return true;
 
-    // If all filters pass, then we do not report
+    // If any filter passes, then we do not report
     if (this.options) {
       const opts: SentryInterceptorOptions = this.options as {}
       if (opts.filters) {
         let filters: SentryInterceptorOptionsFilter[] = opts.filters
-        return filters.every(({ type, filter }) => {
+        return filters.some(({ type, filter }) => {
           return !(exception instanceof type && (!filter || filter(exception)));
         });
       }


### PR DESCRIPTION
Sentry interceptor must report if one of filters passes.

In current implementation, it's expected that all filters should pass, but it does not allow adding complex exception filtering scenarios.

For example filter out 2 different error types.