### PR TITLE
Fix SentryInterceptorOptions request type

### DIFF
--- a/lib/sentry.interfaces.ts
+++ b/lib/sentry.interfaces.ts
@@ -1,7 +1,7 @@
-import { ModuleMetadata, Type } from "@nestjs/common/interfaces";
+import { ModuleMetadata, Type } from '@nestjs/common/interfaces';
 import { Integration, Options } from '@sentry/types';
-import { ConsoleLoggerOptions, HttpException } from "@nestjs/common";
-import { SeverityLevel } from "@sentry/node";
+import { ConsoleLoggerOptions } from '@nestjs/common';
+import { SeverityLevel } from '@sentry/node';
 
 export interface SentryCloseOptions {
     enabled: boolean;
@@ -44,7 +44,7 @@ export interface SentryInterceptorOptions {
     level?: SeverityLevel;
 
     // https://github.com/getsentry/sentry-javascript/blob/master/packages/node/src/handlers.ts#L163
-    request?: boolean;
+    request?: boolean | string[]; // default: true = ['cookies', 'data', 'headers', 'method', 'query_string', 'url']
     serverName?: boolean;
     transaction?: boolean | 'path' | 'methodPath' | 'handler'; // https://github.com/getsentry/sentry-javascript/blob/master/packages/node/src/handlers.ts#L16
     user?: boolean | string[];


### PR DESCRIPTION
### Description:
I discovered a problem with the request type of SentryInterceptorOptions as it is defined as a boolean type and did not allow me to specify the keys to be removed from the request object as described in the sentry documentation.

[Sentry Docs](https://docs.sentry.io/platforms/node/guides/express/)

With this fix, when you use the `SentryInterceptor()` you will have the option to specify the request fields that you want to extract from the request object. The following example extract only the headers from the request:
```typescrypt
@Module({
  imports: [
    SentryModule.forRootAsync({
      imports: [ConfigModule],
      useFactory: async (configService: ConfigService) =>
        configService.get('SENTRY_CONFIG'),
      inject: [ConfigService],
    }),
  ],
  controllers: [AppController],
  providers: [
    {
      provide: APP_INTERCEPTOR,
      useFactory: () =>
        new SentryInterceptor({
          request: ['headers'],
        }),
    },
  ],
})
export class AppModule implements NestModule {}
```

---

### Tests results:
![Captura de pantalla 2023-01-23 a las 14 49 47](https://user-images.githubusercontent.com/57524711/214058278-2296b7de-f9cd-4876-9cff-da9127445524.png)

---

### Sentry results:
![Captura de pantalla 2023-01-23 a las 14 44 07](https://user-images.githubusercontent.com/57524711/214058332-1d5b9e17-7f41-4da2-8940-3b7543b7994a.png)
