### PR TITLE
feat!: added support for v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.7",
       "license": "ISC",
       "devDependencies": {
-        "@nestjs/testing": "^9.0.5",
+        "@nestjs/testing": "10.3.0",
         "@types/jest": "28.1.6",
         "@types/node": "^18.0.6",
         "@types/supertest": "^2.0.12",
@@ -22,11 +22,11 @@
         "typescript": "^4.5.4"
       },
       "optionalDependencies": {
-        "@nestjs/graphql": "^10.0.20"
+        "@nestjs/graphql": "12.0.11"
       },
       "peerDependencies": {
-        "@nestjs/common": "^9.0.4",
-        "@nestjs/core": "^9.0.4",
+        "@nestjs/common": ">= 10.0.0",
+        "@nestjs/core": ">= 10.0.0",
         "@sentry/hub": "^7.7.0",
         "@sentry/node": "^7.7.0",
         "reflect-metadata": "^0.1.13",
@@ -598,68 +598,64 @@
       "dev": true
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.0.tgz",
-      "integrity": "sha512-xRa7RAQok/0DD2YnjuqikMrr7dUAxTpdGtZ7BkvUUGhYs3B3p7reCAfvOVr1DJAqVToP7hdlMk+S5+Ylk+AaqA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.0.tgz",
+      "integrity": "sha512-J7/xqjkGTTwOJmaJQJ2C+VDBDOWJL3lKrHJN4yMaRLAJH3PosB7GiPRaSDZdErs0+F77sH2MKs2haMMkywzx7Q==",
       "optional": true,
       "dependencies": {
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/utils": "^10.0.0",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.2.tgz",
-      "integrity": "sha512-FnBM1PMKQ6y8KlzeFocnEwcGA/IT++z4v+hvvwwXL+IUYDNqmrp9XYNklpQRb/KKSbTtKnQapCWNiVNex7jl+Q==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.0.tgz",
+      "integrity": "sha512-kf3qOXMFcMs2f/S8Y3A8fm/2w+GaHAkfr3Gnhh2LOug/JgpY/ywgFVxO3jOeSpSEdoYcDKLcXVjMigNbY4AdQg==",
       "optional": true,
       "dependencies": {
-        "@graphql-tools/merge": "8.3.4",
-        "@graphql-tools/utils": "8.10.1",
+        "@graphql-tools/merge": "^9.0.0",
+        "@graphql-tools/utils": "^10.0.0",
         "tslib": "^2.4.0",
-        "value-or-promise": "1.0.11"
+        "value-or-promise": "^1.0.12"
       },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/merge": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.4.tgz",
-      "integrity": "sha512-2z1UpHvvI52nQZIYArU+rPq1lOENWetsdb+6vu8yLGyCRP4CpKMBvtmiHkbrlPBO8dItpZ08szXEoaStfJHBxQ==",
-      "optional": true,
-      "dependencies": {
-        "@graphql-tools/utils": "8.10.1",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
-      "version": "8.10.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.10.1.tgz",
-      "integrity": "sha512-UYi/afPvxZ8mz0LjplMxOSmGDPenVS/Q0zJ/6LOyF9yZdJYIDe+J+Qr/I9+rCYQmgBW4BJeRUUc7VoUzZPfZDA==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/utils": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.8.0.tgz",
-      "integrity": "sha512-KJrtx05uSM/cPYFdTnGAS1doL5bftJLAiFCDMZ8Vkifztz3BFn3gpFiy/o4wDtM8s39G46mxmt2Km/RmeltfGw==",
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.0.8.tgz",
+      "integrity": "sha512-yjyA8ycSa1WRlJqyX/aLqXeE5DvF/H02+zXMUFnCzIDrj0UvLMUrxhmVFnMK0Q2n3bh4uuTeY3621m5za9ovXw==",
       "optional": true,
       "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "cross-inspect": "1.0.0",
+        "dset": "^3.1.2",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "optional": true,
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -1013,31 +1009,36 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@nestjs/common": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-9.0.11.tgz",
-      "integrity": "sha512-oYLIcOal3QOwcqt6goXovRNg8ZkalyOMjH0oYYzfJLrait6P7c6nAeWHu4qFDThY7GoZHEanLgji1qlqVEW09g==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.3.0.tgz",
+      "integrity": "sha512-DGv34UHsZBxCM3H5QGE2XE/+oLJzz5+714JQjBhjD9VccFlQs3LRxo/epso4l7nJIiNlZkPyIUC8WzfU/5RTsQ==",
       "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
-        "tslib": "2.4.0",
-        "uuid": "8.3.2"
+        "tslib": "2.6.2",
+        "uid": "2.0.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "cache-manager": "*",
         "class-transformer": "*",
         "class-validator": "*",
         "reflect-metadata": "^0.1.12",
         "rxjs": "^7.1.0"
       },
       "peerDependenciesMeta": {
-        "cache-manager": {
-          "optional": true
-        },
         "class-transformer": {
           "optional": true
         },
@@ -1047,29 +1048,28 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-9.0.11.tgz",
-      "integrity": "sha512-DYyoiWSGebDAG8WSfG/ue88HBU39kAJTi2YXftWdVSl1LFveV+pwKY83P2qX0ND38TS8WktFYpaMkXslf97BBQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.3.0.tgz",
+      "integrity": "sha512-N06P5ncknW/Pm8bj964WvLIZn2gNhHliCBoAO1LeBvNImYkecqKcrmLbY49Fa1rmMfEM3MuBHeDys3edeuYAOA==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
-        "object-hash": "3.0.0",
         "path-to-regexp": "3.2.0",
-        "tslib": "2.4.0",
-        "uuid": "8.3.2"
+        "tslib": "2.6.2",
+        "uid": "2.0.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "@nestjs/common": "^9.0.0",
-        "@nestjs/microservices": "^9.0.0",
-        "@nestjs/platform-express": "^9.0.0",
-        "@nestjs/websockets": "^9.0.0",
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/microservices": "^10.0.0",
+        "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/websockets": "^10.0.0",
         "reflect-metadata": "^0.1.12",
         "rxjs": "^7.1.0"
       },
@@ -1086,36 +1086,44 @@
       }
     },
     "node_modules/@nestjs/graphql": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/graphql/-/graphql-10.1.1.tgz",
-      "integrity": "sha512-j7f3TSH8whFbUeO0xLZ7iw40N7gVrsyB+qnTjInNoJ3A+gs7SiYobszxia9LaeBLs0X/We+uCA9kofeXYI+jnw==",
+      "version": "12.0.11",
+      "resolved": "https://registry.npmjs.org/@nestjs/graphql/-/graphql-12.0.11.tgz",
+      "integrity": "sha512-iCyVs9+utCQt9ehMhUjQcEdjRN/MrcTBINd7P44O1fzGENuWMbt1Z8RCoZbeGi5iVPBY63HgYik+BnnICqmxZw==",
       "optional": true,
       "dependencies": {
-        "@graphql-tools/merge": "8.3.0",
-        "@graphql-tools/schema": "9.0.2",
-        "@graphql-tools/utils": "8.8.0",
-        "@nestjs/mapped-types": "1.1.0",
+        "@graphql-tools/merge": "9.0.0",
+        "@graphql-tools/schema": "10.0.0",
+        "@graphql-tools/utils": "10.0.8",
+        "@nestjs/mapped-types": "2.0.2",
         "chokidar": "3.5.3",
-        "fast-glob": "3.2.11",
+        "fast-glob": "3.3.2",
         "graphql-tag": "2.12.6",
-        "graphql-ws": "5.5.5",
+        "graphql-ws": "5.14.2",
         "lodash": "4.17.21",
         "normalize-path": "3.0.0",
         "subscriptions-transport-ws": "0.11.0",
-        "tslib": "2.4.0",
-        "uuid": "8.3.2",
-        "ws": "8.8.1"
+        "tslib": "2.6.2",
+        "uuid": "9.0.1",
+        "ws": "8.14.2"
       },
       "peerDependencies": {
-        "@apollo/subgraph": "^0.1.5 || ^0.3.0 || ^0.4.0 || ^2.0.0",
-        "@nestjs/common": "^8.2.3 || ^9.0.0",
-        "@nestjs/core": "^8.2.3 || ^9.0.0",
-        "graphql": "^15.8.0 || ^16.0.0",
+        "@apollo/subgraph": "^2.0.0",
+        "@nestjs/common": "^9.3.8 || ^10.0.0",
+        "@nestjs/core": "^9.3.8 || ^10.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "graphql": "^16.6.0",
         "reflect-metadata": "^0.1.13",
-        "ts-morph": "^13.0.2 || ^14.0.0 || ^15.0.0"
+        "ts-morph": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0"
       },
       "peerDependenciesMeta": {
         "@apollo/subgraph": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
           "optional": true
         },
         "ts-morph": {
@@ -1123,15 +1131,28 @@
         }
       }
     },
+    "node_modules/@nestjs/graphql/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@nestjs/mapped-types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.1.0.tgz",
-      "integrity": "sha512-+2kSly4P1QI+9eGt+/uGyPdEG1hVz7nbpqPHWZVYgoqz8eOHljpXPag+UCVRw9zo2XCu4sgNUIGe8Uk0+OvUQg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.2.tgz",
+      "integrity": "sha512-V0izw6tWs6fTp9+KiiPUbGHWALy563Frn8X6Bm87ANLRuE46iuBMD5acKBDP5lKL/75QFvrzSJT7HkCbB0jTpg==",
       "optional": true,
       "peerDependencies": {
-        "@nestjs/common": "^7.0.8 || ^8.0.0 || ^9.0.0",
-        "class-transformer": "^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0",
-        "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0",
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
         "reflect-metadata": "^0.1.12"
       },
       "peerDependenciesMeta": {
@@ -1144,22 +1165,22 @@
       }
     },
     "node_modules/@nestjs/testing": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-9.0.11.tgz",
-      "integrity": "sha512-tT+yj3av7ZJb9Cy09C4+FoUULvzUntf81g5eK5shRVeQ35RWqr7E5Uq77B7ePUF2Er/TictVZk43d7rKq1ClNA==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.3.0.tgz",
+      "integrity": "sha512-8DM+bw1qASCvaEnoHUQhypCOf54+G5R21MeFBMvnSk5DtKaWVZuzDP2GjLeYCpTH19WeP6LrrjHv3rX2LKU02A==",
       "dev": true,
       "dependencies": {
-        "tslib": "2.4.0"
+        "tslib": "2.6.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "@nestjs/common": "^9.0.0",
-        "@nestjs/core": "^9.0.0",
-        "@nestjs/microservices": "^9.0.0",
-        "@nestjs/platform-express": "^9.0.0"
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/core": "^10.0.0",
+        "@nestjs/microservices": "^10.0.0",
+        "@nestjs/platform-express": "^10.0.0"
       },
       "peerDependenciesMeta": {
         "@nestjs/microservices": {
@@ -2003,6 +2024,18 @@
       "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
       "dev": true
     },
+    "node_modules/cross-inspect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.0.tgz",
+      "integrity": "sha512-4PFfn4b5ZN6FMNGSZlyb7wUhuN8wvj8t/VQHZdM4JsDcruGJ8L2kf9zao98QIrBPFCpdk27qst/AGTl7pL3ypQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2083,6 +2116,15 @@
       "dev": true,
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
+      "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2204,9 +2246,9 @@
       }
     },
     "node_modules/fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "optional": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -2240,9 +2282,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
+      "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
       "optional": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -2472,9 +2514,9 @@
       }
     },
     "node_modules/graphql-ws": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.5.5.tgz",
-      "integrity": "sha512-hvyIS71vs4Tu/yUYHPvGXsTgo0t3arU820+lT5VjZS2go0ewp2LqyCgxEN56CzOG7Iys52eRhHBiD1gGRdiQtw==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.14.2.tgz",
+      "integrity": "sha512-LycmCwhZ+Op2GlHz4BZDsUYHKRiiUz+3r9wbhBATMETNlORQJAaFlAgTFoeRh6xQoQegwYwIylVD1Qns9/DA3w==",
       "optional": true,
       "engines": {
         "node": ">=10"
@@ -3667,15 +3709,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/object-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "peer": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
@@ -4624,9 +4657,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -4660,6 +4693,18 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uid": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
+      "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
+      "peer": true,
+      "dependencies": {
+        "@lukeed/csprng": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -4707,6 +4752,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -4726,9 +4772,9 @@
       }
     },
     "node_modules/value-or-promise": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
-      "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+      "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
       "optional": true,
       "engines": {
         "node": ">=12"
@@ -4808,16 +4854,16 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "optional": true,
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -5310,56 +5356,45 @@
       "dev": true
     },
     "@graphql-tools/merge": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.0.tgz",
-      "integrity": "sha512-xRa7RAQok/0DD2YnjuqikMrr7dUAxTpdGtZ7BkvUUGhYs3B3p7reCAfvOVr1DJAqVToP7hdlMk+S5+Ylk+AaqA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.0.tgz",
+      "integrity": "sha512-J7/xqjkGTTwOJmaJQJ2C+VDBDOWJL3lKrHJN4yMaRLAJH3PosB7GiPRaSDZdErs0+F77sH2MKs2haMMkywzx7Q==",
       "optional": true,
       "requires": {
-        "@graphql-tools/utils": "8.8.0",
+        "@graphql-tools/utils": "^10.0.0",
         "tslib": "^2.4.0"
       }
     },
     "@graphql-tools/schema": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.2.tgz",
-      "integrity": "sha512-FnBM1PMKQ6y8KlzeFocnEwcGA/IT++z4v+hvvwwXL+IUYDNqmrp9XYNklpQRb/KKSbTtKnQapCWNiVNex7jl+Q==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.0.tgz",
+      "integrity": "sha512-kf3qOXMFcMs2f/S8Y3A8fm/2w+GaHAkfr3Gnhh2LOug/JgpY/ywgFVxO3jOeSpSEdoYcDKLcXVjMigNbY4AdQg==",
       "optional": true,
       "requires": {
-        "@graphql-tools/merge": "8.3.4",
-        "@graphql-tools/utils": "8.10.1",
+        "@graphql-tools/merge": "^9.0.0",
+        "@graphql-tools/utils": "^10.0.0",
         "tslib": "^2.4.0",
-        "value-or-promise": "1.0.11"
-      },
-      "dependencies": {
-        "@graphql-tools/merge": {
-          "version": "8.3.4",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.4.tgz",
-          "integrity": "sha512-2z1UpHvvI52nQZIYArU+rPq1lOENWetsdb+6vu8yLGyCRP4CpKMBvtmiHkbrlPBO8dItpZ08szXEoaStfJHBxQ==",
-          "optional": true,
-          "requires": {
-            "@graphql-tools/utils": "8.10.1",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@graphql-tools/utils": {
-          "version": "8.10.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.10.1.tgz",
-          "integrity": "sha512-UYi/afPvxZ8mz0LjplMxOSmGDPenVS/Q0zJ/6LOyF9yZdJYIDe+J+Qr/I9+rCYQmgBW4BJeRUUc7VoUzZPfZDA==",
-          "optional": true,
-          "requires": {
-            "tslib": "^2.4.0"
-          }
-        }
+        "value-or-promise": "^1.0.12"
       }
     },
     "@graphql-tools/utils": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.8.0.tgz",
-      "integrity": "sha512-KJrtx05uSM/cPYFdTnGAS1doL5bftJLAiFCDMZ8Vkifztz3BFn3gpFiy/o4wDtM8s39G46mxmt2Km/RmeltfGw==",
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.0.8.tgz",
+      "integrity": "sha512-yjyA8ycSa1WRlJqyX/aLqXeE5DvF/H02+zXMUFnCzIDrj0UvLMUrxhmVFnMK0Q2n3bh4uuTeY3621m5za9ovXw==",
       "optional": true,
       "requires": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "cross-inspect": "1.0.0",
+        "dset": "^3.1.2",
         "tslib": "^2.4.0"
       }
+    },
+    "@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "optional": true,
+      "requires": {}
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -5639,68 +5674,81 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "peer": true
+    },
     "@nestjs/common": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-9.0.11.tgz",
-      "integrity": "sha512-oYLIcOal3QOwcqt6goXovRNg8ZkalyOMjH0oYYzfJLrait6P7c6nAeWHu4qFDThY7GoZHEanLgji1qlqVEW09g==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.3.0.tgz",
+      "integrity": "sha512-DGv34UHsZBxCM3H5QGE2XE/+oLJzz5+714JQjBhjD9VccFlQs3LRxo/epso4l7nJIiNlZkPyIUC8WzfU/5RTsQ==",
       "peer": true,
       "requires": {
         "iterare": "1.2.1",
-        "tslib": "2.4.0",
-        "uuid": "8.3.2"
+        "tslib": "2.6.2",
+        "uid": "2.0.2"
       }
     },
     "@nestjs/core": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-9.0.11.tgz",
-      "integrity": "sha512-DYyoiWSGebDAG8WSfG/ue88HBU39kAJTi2YXftWdVSl1LFveV+pwKY83P2qX0ND38TS8WktFYpaMkXslf97BBQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.3.0.tgz",
+      "integrity": "sha512-N06P5ncknW/Pm8bj964WvLIZn2gNhHliCBoAO1LeBvNImYkecqKcrmLbY49Fa1rmMfEM3MuBHeDys3edeuYAOA==",
       "peer": true,
       "requires": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
-        "object-hash": "3.0.0",
         "path-to-regexp": "3.2.0",
-        "tslib": "2.4.0",
-        "uuid": "8.3.2"
+        "tslib": "2.6.2",
+        "uid": "2.0.2"
       }
     },
     "@nestjs/graphql": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/graphql/-/graphql-10.1.1.tgz",
-      "integrity": "sha512-j7f3TSH8whFbUeO0xLZ7iw40N7gVrsyB+qnTjInNoJ3A+gs7SiYobszxia9LaeBLs0X/We+uCA9kofeXYI+jnw==",
+      "version": "12.0.11",
+      "resolved": "https://registry.npmjs.org/@nestjs/graphql/-/graphql-12.0.11.tgz",
+      "integrity": "sha512-iCyVs9+utCQt9ehMhUjQcEdjRN/MrcTBINd7P44O1fzGENuWMbt1Z8RCoZbeGi5iVPBY63HgYik+BnnICqmxZw==",
       "optional": true,
       "requires": {
-        "@graphql-tools/merge": "8.3.0",
-        "@graphql-tools/schema": "9.0.2",
-        "@graphql-tools/utils": "8.8.0",
-        "@nestjs/mapped-types": "1.1.0",
+        "@graphql-tools/merge": "9.0.0",
+        "@graphql-tools/schema": "10.0.0",
+        "@graphql-tools/utils": "10.0.8",
+        "@nestjs/mapped-types": "2.0.2",
         "chokidar": "3.5.3",
-        "fast-glob": "3.2.11",
+        "fast-glob": "3.3.2",
         "graphql-tag": "2.12.6",
-        "graphql-ws": "5.5.5",
+        "graphql-ws": "5.14.2",
         "lodash": "4.17.21",
         "normalize-path": "3.0.0",
         "subscriptions-transport-ws": "0.11.0",
-        "tslib": "2.4.0",
-        "uuid": "8.3.2",
-        "ws": "8.8.1"
+        "tslib": "2.6.2",
+        "uuid": "9.0.1",
+        "ws": "8.14.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+          "optional": true
+        }
       }
     },
     "@nestjs/mapped-types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.1.0.tgz",
-      "integrity": "sha512-+2kSly4P1QI+9eGt+/uGyPdEG1hVz7nbpqPHWZVYgoqz8eOHljpXPag+UCVRw9zo2XCu4sgNUIGe8Uk0+OvUQg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.2.tgz",
+      "integrity": "sha512-V0izw6tWs6fTp9+KiiPUbGHWALy563Frn8X6Bm87ANLRuE46iuBMD5acKBDP5lKL/75QFvrzSJT7HkCbB0jTpg==",
       "optional": true,
       "requires": {}
     },
     "@nestjs/testing": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-9.0.11.tgz",
-      "integrity": "sha512-tT+yj3av7ZJb9Cy09C4+FoUULvzUntf81g5eK5shRVeQ35RWqr7E5Uq77B7ePUF2Er/TictVZk43d7rKq1ClNA==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.3.0.tgz",
+      "integrity": "sha512-8DM+bw1qASCvaEnoHUQhypCOf54+G5R21MeFBMvnSk5DtKaWVZuzDP2GjLeYCpTH19WeP6LrrjHv3rX2LKU02A==",
       "dev": true,
       "requires": {
-        "tslib": "2.4.0"
+        "tslib": "2.6.2"
       }
     },
     "@nodelib/fs.scandir": {
@@ -6381,6 +6429,15 @@
       "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
       "dev": true
     },
+    "cross-inspect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.0.tgz",
+      "integrity": "sha512-4PFfn4b5ZN6FMNGSZlyb7wUhuN8wvj8t/VQHZdM4JsDcruGJ8L2kf9zao98QIrBPFCpdk27qst/AGTl7pL3ypQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -6439,6 +6496,12 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
       "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
       "dev": true
+    },
+    "dset": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
+      "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
+      "optional": true
     },
     "electron-to-chromium": {
       "version": "1.4.254",
@@ -6528,9 +6591,9 @@
       }
     },
     "fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "optional": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -6561,9 +6624,9 @@
       }
     },
     "fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
+      "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
       "optional": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -6731,9 +6794,9 @@
       }
     },
     "graphql-ws": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.5.5.tgz",
-      "integrity": "sha512-hvyIS71vs4Tu/yUYHPvGXsTgo0t3arU820+lT5VjZS2go0ewp2LqyCgxEN56CzOG7Iys52eRhHBiD1gGRdiQtw==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.14.2.tgz",
+      "integrity": "sha512-LycmCwhZ+Op2GlHz4BZDsUYHKRiiUz+3r9wbhBATMETNlORQJAaFlAgTFoeRh6xQoQegwYwIylVD1Qns9/DA3w==",
       "optional": true,
       "requires": {}
     },
@@ -7630,12 +7693,6 @@
         "path-key": "^3.0.0"
       }
     },
-    "object-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "peer": true
-    },
     "object-inspect": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
@@ -8297,9 +8354,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "type-detect": {
       "version": "4.0.8",
@@ -8318,6 +8375,15 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true
+    },
+    "uid": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
+      "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
+      "peer": true,
+      "requires": {
+        "@lukeed/csprng": "^1.0.0"
+      }
     },
     "update-browserslist-db": {
       "version": "1.0.9",
@@ -8347,7 +8413,8 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true
     },
     "v8-to-istanbul": {
       "version": "9.0.1",
@@ -8361,9 +8428,9 @@
       }
     },
     "value-or-promise": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
-      "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+      "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
       "optional": true
     },
     "walker": {
@@ -8425,9 +8492,9 @@
       }
     },
     "ws": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "optional": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   "author": "Dexter Hardy",
   "license": "ISC",
   "peerDependencies": {
-    "@nestjs/common": "^9.0.4",
-    "@nestjs/core": "^9.0.4",
+    "@nestjs/common": ">= 10.0.0",
+    "@nestjs/core": ">= 10.0.0",
     "@sentry/node": "^7.7.0",
     "@sentry/hub": "^7.7.0",
     "reflect-metadata": "^0.1.13",
@@ -55,7 +55,7 @@
     "testEnvironment": "node"
   },
   "devDependencies": {
-    "@nestjs/testing": "^9.0.5",
+    "@nestjs/testing": "10.3.0",
     "@types/jest": "28.1.6",
     "@types/node": "^18.0.6",
     "@types/supertest": "^2.0.12",
@@ -68,6 +68,6 @@
     "typescript": "^4.5.4"
   },
   "optionalDependencies": {
-    "@nestjs/graphql": "^10.0.20"
+    "@nestjs/graphql": "12.0.11"
   }
 }


### PR DESCRIPTION
Closes #115 
Closes #113

To support v10, we basically need to update Nest version.

I also make the support more open, instead of being locked by major version.

Since it didn't break in the new version, we can also change the `peerDependencies` to `>= 9.0.0` instead, and release it as minor/patch instead of major.