### PR TITLE
refactor!: use original interface option to add request data

### DIFF
--- a/lib/sentry.interceptor.ts
+++ b/lib/sentry.interceptor.ts
@@ -17,7 +17,7 @@ import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 // Sentry imports
 import { Scope } from '@sentry/hub';
-import { Handlers } from '@sentry/node';
+import { Handlers, addRequestDataToEvent } from '@sentry/node';
 
 import { SentryService } from './sentry.service';
 import { SentryInterceptorOptions, SentryInterceptorOptionsFilter } from './sentry.interfaces';
@@ -68,7 +68,7 @@ export class SentryInterceptor implements NestInterceptor {
   }
 
   private captureHttpException(scope: Scope, http: HttpArgumentsHost, exception: HttpException): void {
-    const data = Handlers.parseRequest(<any>{},http.getRequest(), this.options);
+    const data = addRequestDataToEvent(<any>{},http.getRequest(), this.options?.addRequestDataOptions);
 
     scope.setExtra('req', data.request);
     

--- a/lib/sentry.interfaces.ts
+++ b/lib/sentry.interfaces.ts
@@ -1,7 +1,7 @@
-import { ModuleMetadata, Type } from "@nestjs/common/interfaces";
+import { ConsoleLoggerOptions } from '@nestjs/common';
+import { ModuleMetadata, Type } from '@nestjs/common/interfaces';
+import { AddRequestDataToEventOptions } from '@sentry/node';
 import { Integration, Options } from '@sentry/types';
-import { ConsoleLoggerOptions, HttpException } from "@nestjs/common";
-import { SeverityLevel } from "@sentry/node";
 
 export interface SentryCloseOptions {
     enabled: boolean;
@@ -38,15 +38,5 @@ export interface SentryInterceptorOptionsFilter {
 
 export interface SentryInterceptorOptions {
     filters?: SentryInterceptorOptionsFilter[];
-    tags?: { [key: string]: string };
-    extra?: { [key: string]: any };
-    fingerprint?: string[];
-    level?: SeverityLevel;
-
-    // https://github.com/getsentry/sentry-javascript/blob/master/packages/node/src/handlers.ts#L163
-    request?: boolean;
-    serverName?: boolean;
-    transaction?: boolean | 'path' | 'methodPath' | 'handler'; // https://github.com/getsentry/sentry-javascript/blob/master/packages/node/src/handlers.ts#L16
-    user?: boolean | string[];
-    version?: boolean;
+    addRequestDataOptions?: Omit<AddRequestDataToEventOptions, 'deps'>;
 }


### PR DESCRIPTION
Updated version of #105 that uses the new API instead of the older one that will removed in the next `Sentry` version.

But this change is also a breaking change since I prefer to create a new field instead of extending it.